### PR TITLE
Fix build by adding packages: cargo, rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apk --no-cache add \
     libxml2-dev \
     libxslt-dev \
     git \
-    bash && \
+    bash \
+    cargo \
+    rust && \
     # netconf-console installation
     pip3 install git+https://bitbucket.org/martin_volf/ncc/@2.3.0 && \
     find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf && \


### PR DESCRIPTION
Ran a build and noticed that `pip3 install <project>` fails in order to build a dependent package `cryptography`, we need `rust` and `cargo`.

```
Sending build context to Docker daemon  76.29kB
Step 1/13 : FROM python:3.7-alpine as builder
 ---> 93ac4b41defe
Step 2/13 : RUN apk --no-cache add     build-base     python3-dev     libffi-dev     openssl-dev     ncurses-dev     libxml2-dev     libxslt-dev     git     bash &&     pip3 install git+https://bitbucket.org/martin_volf/ncc/@2.3.0 &&     find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf &&     find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 ---> Running in 07805a3b0955
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/42) Installing bash (5.1.4-r0)
Executing bash-5.1.4-r0.post-install
(2/42) Installing libgcc (10.3.1_git20210424-r2)
(3/42) Installing libstdc++ (10.3.1_git20210424-r2)
(4/42) Installing binutils (2.35.2-r2)
(5/42) Installing libmagic (5.40-r1)
(6/42) Installing file (5.40-r1)
(7/42) Installing libgomp (10.3.1_git20210424-r2)
(8/42) Installing libatomic (10.3.1_git20210424-r2)
(9/42) Installing libgphobos (10.3.1_git20210424-r2)
(10/42) Installing gmp (6.2.1-r0)
(11/42) Installing isl22 (0.22-r0)
(12/42) Installing mpfr4 (4.1.0-r0)
(13/42) Installing mpc1 (1.2.1-r0)
(14/42) Installing gcc (10.3.1_git20210424-r2)
(15/42) Installing musl-dev (1.2.2-r3)
(16/42) Installing libc-dev (0.7.2-r3)
(17/42) Installing g++ (10.3.1_git20210424-r2)
(18/42) Installing make (4.3-r0)
(19/42) Installing fortify-headers (1.1-r1)
(20/42) Installing patch (2.7.6-r7)
(21/42) Installing build-base (0.5-r2)
(22/42) Installing brotli-libs (1.0.9-r5)
(23/42) Installing nghttp2-libs (1.43.0-r0)
(24/42) Installing libcurl (7.77.0-r1)
(25/42) Installing pcre2 (10.36-r0)
(26/42) Installing git (2.32.0-r0)
(27/42) Installing linux-headers (5.10.41-r0)
(28/42) Installing pkgconf (1.7.4-r0)
(29/42) Installing libffi-dev (3.3-r2)
(30/42) Installing zlib-dev (1.2.11-r3)
(31/42) Installing xz-dev (5.2.5-r0)
(32/42) Installing libxml2 (2.9.12-r1)
(33/42) Installing libxml2-dev (2.9.12-r1)
(34/42) Installing libgpg-error (1.42-r0)
(35/42) Installing libgcrypt (1.9.3-r0)
(36/42) Installing libxslt (1.1.34-r1)
(37/42) Installing libxslt-dev (1.1.34-r1)
(38/42) Installing ncurses-dev (6.2_p20210612-r0)
(39/42) Installing openssl-dev (1.1.1k-r0)
(40/42) Installing mpdecimal (2.5.1-r1)
(41/42) Installing python3 (3.9.5-r1)
(42/42) Installing python3-dev (3.9.5-r1)
Executing busybox-1.33.1-r2.trigger
OK: 326 MiB in 77 packages
Collecting git+https://bitbucket.org/martin_volf/ncc/@2.3.0
  Cloning https://bitbucket.org/martin_volf/ncc/ (to revision 2.3.0) to /tmp/pip-req-build-8v6fbdyj
  Running command git clone -q https://bitbucket.org/martin_volf/ncc/ /tmp/pip-req-build-8v6fbdyj
Collecting paramiko>=2.5.0
  Downloading paramiko-2.7.2-py2.py3-none-any.whl (206 kB)
Collecting ncclient<=0.6.7,>=0.6.5
  Downloading ncclient-0.6.7.tar.gz (605 kB)
Requirement already satisfied: setuptools>0.6 in /usr/local/lib/python3.7/site-packages (from ncclient<=0.6.7,>=0.6.5->netconf-console==2.3.0) (57.0.0)
Collecting lxml>=3.3.0
  Downloading lxml-4.6.3.tar.gz (3.2 MB)
Collecting six
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting cryptography>=2.5
  Downloading cryptography-3.4.7.tar.gz (546 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Collecting bcrypt>=3.1.3
  Downloading bcrypt-3.2.0.tar.gz (42 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Collecting pynacl>=1.0.1
  Downloading PyNaCl-1.4.0.tar.gz (3.4 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Collecting cffi>=1.1
  Using cached cffi-1.14.6-cp37-cp37m-linux_x86_64.whl
Collecting pycparser
  Using cached pycparser-2.20-py2.py3-none-any.whl (112 kB)
Building wheels for collected packages: netconf-console, ncclient, lxml, bcrypt, cryptography, pynacl
  Building wheel for netconf-console (setup.py): started
  Building wheel for netconf-console (setup.py): finished with status 'done'
  Created wheel for netconf-console: filename=netconf_console-2.3.0-py2.py3-none-any.whl size=18494 sha256=f7e5772fc6f748e9a98df0c31e318b3bbeba0ae0c97635275e6a37d5b52406b3
  Stored in directory: /tmp/pip-ephem-wheel-cache-cuwd4hrf/wheels/23/bf/a6/2e56c3f58d534660ad9ef55a5cb975c4592d1f70c2beec1ff4
  Building wheel for ncclient (setup.py): started
  Building wheel for ncclient (setup.py): finished with status 'done'
  Created wheel for ncclient: filename=ncclient-0.6.7-py2.py3-none-any.whl size=99693 sha256=3720dc9153b82c711de1d234afa14dba4eb479b604d249fe46faf9111344733f
  Stored in directory: /root/.cache/pip/wheels/00/a2/fc/e78f00d54361dba0d4fc6a21195a71e89add64873faadc0f48
  Building wheel for lxml (setup.py): started
  Building wheel for lxml (setup.py): still running...
  Building wheel for lxml (setup.py): finished with status 'done'
  Created wheel for lxml: filename=lxml-4.6.3-cp37-cp37m-linux_x86_64.whl size=1607153 sha256=cb512e931609efd49262bb5b0ac4cd38616b5d5c35534431292f34d4fc34b924
  Stored in directory: /root/.cache/pip/wheels/9f/42/6a/bbf7f1f947280542bb9349701b72a087aa04db32ce34b14d1b
  Building wheel for bcrypt (PEP 517): started
  Building wheel for bcrypt (PEP 517): finished with status 'done'
  Created wheel for bcrypt: filename=bcrypt-3.2.0-cp37-cp37m-linux_x86_64.whl size=32268 sha256=7cb38eac5df616c7f4a2b8fca696497311811d8506e61a5dfd70cb510a85822f
  Stored in directory: /root/.cache/pip/wheels/c8/ef/5b/5866ddf8e9944d7968fcb3782ad6a68f234bdd13ec3b04ee7c
  Building wheel for cryptography (PEP 517): started
  Building wheel for cryptography (PEP 517): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python /usr/local/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /tmp/tmpwz3xy393
       cwd: /tmp/pip-install-vq818h0h/cryptography_503aa1c247714111a95879f068923c13
  Complete output (165 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.7
  creating build/lib.linux-x86_64-3.7/cryptography
  copying src/cryptography/exceptions.py -> build/lib.linux-x86_64-3.7/cryptography
  copying src/cryptography/fernet.py -> build/lib.linux-x86_64-3.7/cryptography
  copying src/cryptography/__init__.py -> build/lib.linux-x86_64-3.7/cryptography
  copying src/cryptography/utils.py -> build/lib.linux-x86_64-3.7/cryptography
  copying src/cryptography/__about__.py -> build/lib.linux-x86_64-3.7/cryptography
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat
  copying src/cryptography/hazmat/_oid.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat
  copying src/cryptography/hazmat/_der.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat
  copying src/cryptography/hazmat/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat
  copying src/cryptography/hazmat/_types.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat
  creating build/lib.linux-x86_64-3.7/cryptography/x509
  copying src/cryptography/x509/oid.py -> build/lib.linux-x86_64-3.7/cryptography/x509
  copying src/cryptography/x509/name.py -> build/lib.linux-x86_64-3.7/cryptography/x509
  copying src/cryptography/x509/general_name.py -> build/lib.linux-x86_64-3.7/cryptography/x509
  copying src/cryptography/x509/ocsp.py -> build/lib.linux-x86_64-3.7/cryptography/x509
  copying src/cryptography/x509/base.py -> build/lib.linux-x86_64-3.7/cryptography/x509
  copying src/cryptography/x509/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/x509
  copying src/cryptography/x509/certificate_transparency.py -> build/lib.linux-x86_64-3.7/cryptography/x509
  copying src/cryptography/x509/extensions.py -> build/lib.linux-x86_64-3.7/cryptography/x509
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/interfaces.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/bindings
  copying src/cryptography/hazmat/bindings/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/bindings
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/padding.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/poly1305.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/keywrap.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/constant_time.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_serialization.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/cmac.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hashes.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_asymmetric.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hmac.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_cipheralgorithm.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed25519.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed448.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x25519.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/backend.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x509.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ocsp.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/aead.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/poly1305.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ciphers.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dh.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/utils.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x448.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/rsa.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dsa.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/cmac.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/decode_asn1.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hashes.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hmac.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ec.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/encode_asn1.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/backends/openssl
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/_conditional.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/binding.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/bindings/openssl
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed25519.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed448.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x25519.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/padding.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dh.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/utils.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x448.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/rsa.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dsa.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ec.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/asymmetric
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/hkdf.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/kbkdf.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/concatkdf.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/x963kdf.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/scrypt.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/pbkdf2.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/kdf
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/ssh.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/base.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs7.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs12.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/serialization
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/utils.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/totp.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/hotp.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/twofactor
  creating build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/modes.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/aead.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/base.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/algorithms.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/__init__.py -> build/lib.linux-x86_64-3.7/cryptography/hazmat/primitives/ciphers
  running egg_info
  writing src/cryptography.egg-info/PKG-INFO
  writing dependency_links to src/cryptography.egg-info/dependency_links.txt
  writing requirements to src/cryptography.egg-info/requires.txt
  writing top-level names to src/cryptography.egg-info/top_level.txt
  reading manifest file 'src/cryptography.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  no previously-included directories found matching 'docs/_build'
  warning: no previously-included files found matching 'vectors'
  warning: no previously-included files matching '*' found under directory 'vectors'
  warning: no previously-included files matching '*' found under directory '.github'
  warning: no previously-included files found matching 'release.py'
  warning: no previously-included files found matching '.coveragerc'
  warning: no previously-included files found matching 'codecov.yml'
  warning: no previously-included files found matching '.readthedocs.yml'
  warning: no previously-included files found matching 'dev-requirements.txt'
  warning: no previously-included files found matching 'tox.ini'
  warning: no previously-included files found matching 'mypy.ini'
  warning: no previously-included files matching '*' found under directory '.zuul.d'
  warning: no previously-included files matching '*' found under directory '.zuul.playbooks'
  adding license file 'LICENSE'
  adding license file 'LICENSE.APACHE'
  adding license file 'LICENSE.BSD'
  adding license file 'LICENSE.PSF'
  writing manifest file 'src/cryptography.egg-info/SOURCES.txt'
  copying src/cryptography/py.typed -> build/lib.linux-x86_64-3.7/cryptography
  running build_ext
  generating cffi module 'build/temp.linux-x86_64-3.7/_padding.c'
  creating build/temp.linux-x86_64-3.7
  generating cffi module 'build/temp.linux-x86_64-3.7/_openssl.c'
  running build_rust
  
      =============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation.html for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq.html
      4) Ensure you have a recent Rust toolchain installed:
         https://cryptography.io/en/latest/installation.html#rust
      5) If you are experiencing issues with Rust for *this release only* you may
         set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
      =============================DEBUG ASSISTANCE=============================
  
  error: can't find Rust compiler
  
  If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
  
  To update pip, run:
  
      pip install --upgrade pip
  
  and then retry package installation.
  
  If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
  
  This package requires Rust >=1.41.0.
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
  Building wheel for pynacl (PEP 517): started
  Building wheel for pynacl (PEP 517): still running...
  Building wheel for pynacl (PEP 517): finished with status 'done'
  Created wheel for pynacl: filename=PyNaCl-1.4.0-cp37-cp37m-linux_x86_64.whl size=274790 sha256=41e1a96ed22c47bbcffb8d05df237b412057a6f1964814cc391f62da4aebb418
  Stored in directory: /root/.cache/pip/wheels/f9/fb/34/d15387bc2e4a748e0eb2b9788c34e1d0c2167265e04bc6bb49
Successfully built netconf-console ncclient lxml bcrypt pynacl
Failed to build cryptography
ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
The command '/bin/sh -c apk --no-cache add     build-base     python3-dev     libffi-dev     openssl-dev     ncurses-dev     libxml2-dev     libxslt-dev     git     bash &&     pip3 install git+https://bitbucket.org/martin_volf/ncc/@2.3.0 &&     find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf &&     find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf' returned a non-zero code: 1

```